### PR TITLE
Update to 22.08 runtime, and use our own libs

### DIFF
--- a/com.poweriso.PowerISO.json
+++ b/com.poweriso.PowerISO.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.poweriso.PowerISO",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "poweriso-gui",
     "finish-args": [

--- a/com.poweriso.PowerISO.json
+++ b/com.poweriso.PowerISO.json
@@ -32,14 +32,28 @@
                     "type": "archive",
                     "url": "https://www.poweriso.com/poweriso-x64-1.1.tar.gz",
                     "sha256": "d30cbf69b6b3f65241b909e7e26acba133993f440f3dbdf86f362889108aab44",
-                    "dest": "gui"
+                    "dest": "gui",
+                    "x-checker-data": {
+                        "is-main-source": true,
+                        "type": "html",
+                        "url": "https://www.poweriso.com/download-poweriso-for-linux.htm",
+                        "version-pattern": "PowerISO for Linux v([\\d\\.-]*) \\(64 bit edition\\)",
+                        "url-template": "https://www.poweriso.com/poweriso-x64-$version.tar.gz"
+                    }
                 },
                 {
                     "type": "archive",
                     "url": "https://www.poweriso.com/poweriso-1.5.tar.gz",
                     "sha256": "1893189e0c8b77da179df64a64cf8e62c4216684d1ab262867c6c96faae64ee2",
                     "strip-components": 0,
-                    "dest": "cli"
+                    "dest": "cli",
+                    "x-checker-data": {
+                        "is-important": true,
+                        "type": "html",
+                        "url": "https://www.poweriso.com/download-poweriso-command-line-utility-for-linux.htm",
+                        "version-pattern": "\\(v([\\d\\.-]*), File size:",
+                        "url-template": "https://www.poweriso.com/poweriso-$version.tar.gz"
+                    }
                 },
                 {
                     "type": "file",

--- a/com.poweriso.PowerISO.json
+++ b/com.poweriso.PowerISO.json
@@ -9,6 +9,7 @@
         "--device=all",
         /* Only supports X11 with the builtin Qt */
         "--env=QT_QPA_PLATFORM_PLUGIN_PATH=/app/lib",
+        "--unset-env=QT_QPA_PLATFORM",
         "--socket=x11",
         "--filesystem=home"
     ],

--- a/com.poweriso.PowerISO.json
+++ b/com.poweriso.PowerISO.json
@@ -8,6 +8,7 @@
         "--allow=multiarch",
         "--device=all",
         /* Only supports X11 with the builtin Qt */
+        "--env=QT_QPA_PLATFORM_PLUGIN_PATH=/app/lib",
         "--socket=x11",
         "--filesystem=home"
     ],
@@ -19,7 +20,7 @@
                 "mkdir /app/lib/",
                 "cp -r ./gui/ /app/lib/poweriso/",
                 "mkdir -p /app/bin/",
-                "install -m755 launcher.sh /app/bin/poweriso-gui",
+                "ln -s ${FLATPAK_DEST}/lib/poweriso/poweriso ${FLATPAK_DEST}/bin/poweriso-gui",
                 "install -m755 cli/poweriso /app/bin/poweriso",
                 "install -Dm644 com.poweriso.PowerISO.png /app/share/icons/com.poweriso.PowerISO.png",
                 "install -Dm644 com.poweriso.PowerISO.desktop /app/share/applications/com.poweriso.PowerISO.desktop",
@@ -50,10 +51,6 @@
                 {
                     "type": "file",
                     "path": "com.poweriso.PowerISO.desktop"
-                },
-                {
-                    "type": "file",
-                    "path": "launcher.sh"
                 }
             ]
         }

--- a/com.poweriso.PowerISO.json
+++ b/com.poweriso.PowerISO.json
@@ -15,9 +15,29 @@
     ],
     "modules": [
         {
+            "name": "patchelf",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/NixOS/patchelf/archive/0.14.3.tar.gz",
+                    "sha256": "827a8ca914c69413f1ca0d967a637980a24edf000a938531a77e663317c853bb",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 2598,
+                        "stable-only": true,
+                        "url-template": "https://github.com/NixOS/patchelf/archive/$version.tar.gz"
+                    }
+                }
+            ],
+            "cleanup": [
+                "*"
+            ]
+        },
+        {
             "name": "poweriso",
             "buildsystem": "simple",
             "build-commands": [
+                "patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 gui/poweriso",
                 "mkdir -p /app/lib/",
                 "cp -r ./gui/ /app/lib/poweriso/",
                 "mkdir -p /app/bin/",

--- a/com.poweriso.PowerISO.json
+++ b/com.poweriso.PowerISO.json
@@ -13,7 +13,98 @@
         "--socket=x11",
         "--filesystem=home"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "*.a",
+        "*.la"
+    ],
     "modules": [
+        {
+            "name": "icu",
+            "subdir": "source",
+            "config-opts": [
+                "--sbindir=${FLATPAK_DEST}/bin",
+                "--disable-extras",
+                "--disable-icuio",
+                "--disable-layout",
+                "--disable-layoutx",
+                "--disable-tests",
+                "--disable-samples"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/unicode-org/icu/releases/download/release-56-1/icu4c-56_1-src.tgz",
+                    "sha256": "3a64e9105c734dcf631c0b3ed60404531bce6c0f5a64bfe1a6402a4cc2314816"
+                }
+            ],
+            "cleanup": [
+                "/bin",
+                "/lib/icu",
+                "/lib/libicutest.so*",
+                "/lib/libicutu.so*",
+                "/share/icu",
+                "/share/man"
+            ]
+        },
+        {
+            "name": "libbsd",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://libbsd.freedesktop.org/releases/libbsd-0.11.3.tar.xz",
+                    "sha256": "ff95cf8184151dacae4247832f8d4ea8800fa127dbd15033ecfe839f285b42a1",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1567,
+                        "stable-only": true,
+                        "url-template": "https://libbsd.freedesktop.org/releases/libbsd-$version.tar.xz"
+                    }
+                }
+            ],
+            "cleanup": [
+                "/share/man"
+            ],
+            "modules": [
+                {
+                    "name": "libmd",
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://libbsd.freedesktop.org/releases/libmd-1.0.4.tar.xz",
+                            "sha256": "f51c921042e34beddeded4b75557656559cf5b1f2448033b4c1eec11c07e530f",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 15525,
+                                "stable-only": true,
+                                "url-template": "https://libbsd.freedesktop.org/releases/libmd-$version.tar.xz"
+                            }
+                        }
+                    ],
+                    "cleanup": [
+                        "/share/man"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "libuuid",
+            "config-opts": [
+                "--disable-all-programs",
+                "--enable-libuuid"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.tar.xz",
+                    "sha256": "6d111cbe4d55b336db2f1fbeffbc65b89908704c01136371d32aa9bec373eb64"
+                }
+            ],
+            "cleanup": [
+                "/sbin"
+            ]
+        },
         {
             "name": "patchelf",
             "sources": [
@@ -38,11 +129,9 @@
             "buildsystem": "simple",
             "build-commands": [
                 "patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 gui/poweriso",
-                "mkdir -p /app/lib/",
-                "cp -r ./gui/ /app/lib/poweriso/",
-                "mkdir -p /app/bin/",
-                "ln -s ${FLATPAK_DEST}/lib/poweriso/poweriso ${FLATPAK_DEST}/bin/poweriso-gui",
-                "install -m755 cli/poweriso /app/bin/poweriso",
+                "install -Dm755 gui/lib{Qt5*,qxcb}.so* -t ${FLATPAK_DEST}/lib/",
+                "install -Dm755 gui/poweriso ${FLATPAK_DEST}/bin/poweriso-gui",
+                "install -Dm755 cli/poweriso -t ${FLATPAK_DEST}/bin/",
                 "install -Dm644 ${FLATPAK_ID}.png -t ${FLATPAK_DEST}/share/icons/",
                 "install -Dm644 ${FLATPAK_ID}.desktop -t ${FLATPAK_DEST}/share/applications/",
                 "install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/"

--- a/com.poweriso.PowerISO.json
+++ b/com.poweriso.PowerISO.json
@@ -43,9 +43,9 @@
                 "mkdir -p /app/bin/",
                 "ln -s ${FLATPAK_DEST}/lib/poweriso/poweriso ${FLATPAK_DEST}/bin/poweriso-gui",
                 "install -m755 cli/poweriso /app/bin/poweriso",
-                "install -Dm644 com.poweriso.PowerISO.png /app/share/icons/com.poweriso.PowerISO.png",
-                "install -Dm644 com.poweriso.PowerISO.desktop /app/share/applications/com.poweriso.PowerISO.desktop",
-                "install -Dm644 com.poweriso.PowerISO.metainfo.xml /app/share/metainfo/com.poweriso.PowerISO.metainfo.xml"
+                "install -Dm644 ${FLATPAK_ID}.png -t ${FLATPAK_DEST}/share/icons/",
+                "install -Dm644 ${FLATPAK_ID}.desktop -t ${FLATPAK_DEST}/share/applications/",
+                "install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/"
             ],
             "sources": [
                 {

--- a/com.poweriso.PowerISO.json
+++ b/com.poweriso.PowerISO.json
@@ -18,7 +18,7 @@
             "name": "poweriso",
             "buildsystem": "simple",
             "build-commands": [
-                "mkdir /app/lib/",
+                "mkdir -p /app/lib/",
                 "cp -r ./gui/ /app/lib/poweriso/",
                 "mkdir -p /app/bin/",
                 "ln -s ${FLATPAK_DEST}/lib/poweriso/poweriso ${FLATPAK_DEST}/bin/poweriso-gui",

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
+    "require-important-update": true
 }

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-OLDDIR=`pwd`
-LIBDIR=/app/lib/poweriso
-export LD_LIBRARY_PATH=$LIBDIR
-export QT_QPA_PLATFORM_PLUGIN_PATH=$LIBDIR
-# export QT_DEBUG_PLUGINS=1
-cd $LIBDIR
-exec ./poweriso


### PR DESCRIPTION
* Bump to the latest 21.08 Freedesktop runtime
* Use runtime's libs as much as possible, and build from source what's still needed.
* Set interpreter with patchelf to the runtime's one
* Drop unneeded wrapper script
* Unset `QT_QPA_PLATFORM` to avoid having the app break when user set it
  globally to wayland. This is not an issue anymore with KDE Plasma, but it's a
  good service to the user
* Add f-e-d-c properties, and drop the unsupported JSON comment which
  will be removed by f-e-d-c

This needs to be tested to confirm that nothing is broken. As far as I can tell, it's working correctly.